### PR TITLE
[chore] dynamic lint rule added

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
   "rules": {
     "@cspell/spellchecker": ["error", {}],
     "@typescript-eslint/consistent-type-definitions": "off",
+    "@typescript-eslint/no-unused-vars": "warn",
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -46,7 +47,6 @@
       }
     ],
     "import/prefer-default-export": "off",
-    "no-console": "warn",
     "no-unused-vars": "off",
     "prettier/prettier": [
       "error",

--- a/lint-rules/boundary.json
+++ b/lint-rules/boundary.json
@@ -56,7 +56,7 @@
       { "pattern": "src/types", "type": "types" },
       { "pattern": "src/utils", "type": "utils" },
       { "pattern": "src/pages", "type": "pages" },
-      { "pattern": "src/styles", "type": "pages" }
+      { "pattern": "src/styles", "type": "styles" }
     ]
   }
 }

--- a/lint-rules/commit-rule.json
+++ b/lint-rules/commit-rule.json
@@ -1,0 +1,7 @@
+{
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "error",
+    "no-console": "error"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "private": true,
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
+      "eslint --fix -c lint-rules/commit-rule.json",
       "bash -c tsc --noEmit --pretty"
     ]
   },

--- a/setting_description/Environment.md
+++ b/setting_description/Environment.md
@@ -95,3 +95,25 @@ pnpm lint-staged
   // ...omitted
 }
 ```
+
+### 4-1. husky specific lint rule
+
+- Using console.log for debugging is common in programming. However, it should not be present in the final codebase as it is not part of the business logic. Excessive use of console.log can result in an overloaded console with irrelevant information during development.
+- The same applies to unused variables, which can clutter the code and lead to potential confusion or errors.
+- Such items should not be merged into the codebase. However, during product development, they are commonly used for debugging and are not as critical as other lint rule errors. If ESLint flags these as “errors” in the codebase, it can be challenging to identify the real issues.
+- Therefore, these are marked as warnings in VSCode but as errors in Husky (githook). This setting is a matter of personal preference and can be adjusted by users accordingly.
+- The code snippet below demonstrates how to mark these issues as warnings in VSCode and as errors during the commit check process.
+
+```json
+// package.json
+{
+  // ...omitted
+  "lint-staged": {
+    "**/*.{js,jsx,ts,tsx}": [
+      "eslint --fix -c lint-rules/commit-rule.json", // changed line
+      "bash -c tsc --noEmit --pretty"
+    ]
+  }
+  // ...omitted
+}
+```

--- a/setting_description/Linting_and_Formating.md
+++ b/setting_description/Linting_and_Formating.md
@@ -214,3 +214,4 @@ pnpm add -D eslint-plugin-boundaries
 - For project-wide shared items, the naming convention requires them to start with “Global” (PascalCase or camelCase) to ensure consistency and easy identification from code base.
 - No need to download anything cos it's from `@typescript-eslint`.
 - There is no need to download anything additional, as it is included with @typescript-eslint.
+

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Inter } from "next/font/google";
 import Head from "next/head";
 import Image from "next/image";
@@ -9,11 +7,6 @@ import styles from "@/styles/Home.module.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export default function Home() {
-  const test = 3;
-
-  const test2 = "3";
-  const hi = test2 + test;
-  const test1g: any = 3;
   return (
     <>
       <Head>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,
+    "noUnusedLocals": false,
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
- In the development environment, no-unused-vars and no-console are flagged as warnings.
- During the pre-commit process, these rules are flagged as errors.