### PR TITLE
[chore] forbid props destructuring, add globalOmit

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "@cspell/spellchecker": ["error", {}],
     "@typescript-eslint/consistent-type-definitions": "off",
     "@typescript-eslint/no-unused-vars": "warn",
+    "arrow-body-style": "off",
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,18 @@
       }
     ],
     "import/prefer-default-export": "off",
-
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "importNames": ["it"],
+            "message": "Please use \"test\" instead of \"it\" from vitest.",
+            "name": "vitest"
+          }
+        ]
+      }
+    ],
     "no-restricted-syntax": [
       "error",
       {
@@ -67,6 +78,7 @@
         "usePrettierrc": true
       }
     ],
+    "react/destructuring-assignment": ["error", "never"],
     "react/function-component-definition": [
       "error",
       {

--- a/__test__/utils/globalOmit.test.ts
+++ b/__test__/utils/globalOmit.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { globalOmit } from "@/utils/globalOmit";
+
+describe("globalOmit", () => {
+  test("should omit specified keys from the object", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = globalOmit(obj, "a", "c");
+    expect(result).toEqual({ b: 2 });
+  });
+
+  test("should return the same object if no keys are specified", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = globalOmit(obj);
+    expect(result).toEqual(obj);
+  });
+
+  test("should return an empty object if all keys are specified", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = globalOmit(obj, "a", "b", "c");
+    expect(result).toEqual({});
+  });
+});

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import * as style from "./index.css";
 
-export default function Home() {
+export default () => {
   return <h2 className={style.heading}>Index Page</h2>;
-}
+};

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+
 import "./button.css";
+import { globalOmit } from "@/utils/globalOmit";
 
 export interface ButtonProps {
   /**
@@ -27,15 +29,24 @@ export interface ButtonProps {
 /**
  * Primary UI component for user interaction
  */
-export const Button = ({ primary = false, size = "medium", backgroundColor, label, ...props }: ButtonProps) => {
-  const mode = primary ? "storybook-button--primary" : "storybook-button--secondary";
+
+// { primary = false, size = "medium", backgroundColor, label, ...props }: ButtonProps
+export const Button = (props: ButtonProps) => {
+  const omittedProps = globalOmit(props, "primary", "size", "backgroundColor", "label");
+
+  const mode = props.primary ? "storybook-button--primary" : "storybook-button--secondary";
+
   return (
-    <button className={["storybook-button", `storybook-button--${size}`, mode].join(" ")} type="button" {...props}>
-      {label}
+    <button
+      className={["storybook-button", `storybook-button--${props.size}`, mode].join(" ")}
+      type="button"
+      {...omittedProps}
+    >
+      {props.label}
       {/* eslint-disable-next-line react/no-unknown-property */}
       <style jsx>{`
         button {
-          background-color: ${backgroundColor};
+          background-color: ${props.backgroundColor};
         }
       `}</style>
     </button>

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -30,7 +30,6 @@ export interface ButtonProps {
  * Primary UI component for user interaction
  */
 
-// { primary = false, size = "medium", backgroundColor, label, ...props }: ButtonProps
 export const Button = (props: ButtonProps) => {
   const omittedProps = globalOmit(props, "primary", "size", "backgroundColor", "label");
 
@@ -52,3 +51,8 @@ export const Button = (props: ButtonProps) => {
     </button>
   );
 };
+
+Button.defaultProps = {
+  primary: false,
+  size: "medium",
+} as ButtonProps;

--- a/src/utils/globalOmit/index.ts
+++ b/src/utils/globalOmit/index.ts
@@ -1,0 +1,13 @@
+export const globalOmit = <T extends object>(targetObj: T, ...keys: (keyof T)[]) => {
+  if (typeof targetObj === "object" && targetObj !== null) {
+    return Object.keys(targetObj).reduce((_result, _currentKey) => {
+      const result = _result;
+      const currentKey = _currentKey as keyof T;
+      if (!keys.includes(currentKey)) {
+        result[currentKey] = targetObj[currentKey];
+      }
+      return result;
+    }, {} as Partial<T>);
+  }
+  return null;
+};


### PR DESCRIPTION
- Forbid props destructuring for readability and maintainability
- Add globalOmit that omits properties from object
- Turn off `arrow-body-style` for productivity
-  Add `no-restricted-imports` rule from vitest - it function to improve readability and intuitiveness