### PR TITLE
[ENV] git hook

### DIFF
--- a/project/.husky/pre-push
+++ b/project/.husky/pre-push
@@ -9,8 +9,6 @@ echo
 
 if [ "$line_count" -gt 6 ]; then
   echo "\033[31mLinting failed or there are warnings. Please add and commit your code, then push again.\033[0m"
-  exit 1
-  
 else
   echo "\033[32mLinting passed with no warnings or errors.\033[0m"
 fi


### PR DESCRIPTION
- delete exit command for flexibility.
- The logic is depends on tex output line which can be flakey. exit command has been removed and it's on user's choice if they are going to re add and commit the changes or not.